### PR TITLE
Fixed broken login due to Mint.com changes

### DIFF
--- a/lib/minty/cli/accounts.rb
+++ b/lib/minty/cli/accounts.rb
@@ -37,7 +37,7 @@ module Minty
 
       def exec
         table = Text::Table.new
-        table.head = %w[Name Value Type]
+        table.head = %w[Name Type Value]
         accounts do |account|
           table.rows << [account.name, account.type.capitalize, Utils.dollars(account.value)]
         end

--- a/lib/minty/client.rb
+++ b/lib/minty/client.rb
@@ -37,9 +37,9 @@ module Minty
 
     def accounts
       login {
-        response_body = agent.post("bundledServiceController.xevent", "token" => @token, "input" => ACCOUNT_REQUEST.to_json).body
+        response_body = agent.get("app/getJsonData.xevent?task=accounts").body
         parsed_body = ::JSON.parse(response_body)
-        accounts = parsed_body["response"]["com.rubygem.minty"].fetch("response") { [] }
+        accounts = parsed_body["set"][0]["data"]
 
         Minty::Objects::Account.build(accounts)
       }

--- a/lib/minty/objects/account.rb
+++ b/lib/minty/objects/account.rb
@@ -6,6 +6,7 @@ module Minty
 
       def self.build(json)
         json.each_with_object([]) do |account, list|
+          account['value'] = account['value'].sub("\u2013", '-').delete('$').to_f
           list.concat [self.new(account)]
         end
       end
@@ -13,8 +14,8 @@ module Minty
       attribute :id
       attribute :name
       attribute :value
-      attribute :type, 'accountType'
-      attribute :balance, 'currentBalance'
+      attribute :type, 'klass'
+      attribute :balance, 'bal'
 
       def active?
         !!json['isActive']


### PR DESCRIPTION
This pull request only updates the login process. As mentioned, Mint updated their login form at some point so that it uses Javascript, so Mechanize can't find the login form - the old method breaks at `page.form_with(id: "form-login")`
