### PR TITLE
Use TLS 1.2 instead of SSL 3.0

### DIFF
--- a/lib/minty/agent.rb
+++ b/lib/minty/agent.rb
@@ -8,7 +8,7 @@ module Minty
 
     def initialize
       @mechanize = ::Mechanize.new do |a|
-        a.ssl_version = 'SSLv3'
+        a.ssl_version = 'TLSv1_2'
         a.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
     end

--- a/lib/minty/objects/account.rb
+++ b/lib/minty/objects/account.rb
@@ -6,7 +6,7 @@ module Minty
 
       def self.build(json)
         json.each_with_object([]) do |account, list|
-          account['value'] = account['value'].sub("\u2013", '-').delete('$').to_f
+          account['value'] = account['value'].delete(',').sub("\u2013", '-').delete('$').to_f
           list.concat [self.new(account)]
         end
       end


### PR DESCRIPTION
As of 11/5/2014 Mint stopped supporting SSL 3.0.

This fixes the broken login issue.
