### PR TITLE
Security tweak cleanup

### DIFF
--- a/lib/minty/credentials.rb
+++ b/lib/minty/credentials.rb
@@ -57,6 +57,7 @@ module Minty
         store['mint_email'] = email.strip
         store['mint_password'] = password.strip
       }
+      FileUtils.chmod(0600, self.class.file)
       self
     end
 

--- a/lib/minty/credentials.rb
+++ b/lib/minty/credentials.rb
@@ -3,17 +3,10 @@ require 'yaml/store'
 require 'etc'
 require 'pathname'
 require 'fileutils'
+require 'openssl'
 
 module Minty
   class Credentials
-
-    def self.load
-      config = YAML.load_file file
-      new(config['mint_email'], config['mint_password'])
-    rescue => e
-      new('', '').save
-    end
-
     def self.system_user
       Etc.getlogin
     end
@@ -31,18 +24,29 @@ module Minty
       FileUtils.rm_r file
     end
 
-    attr_writer :email, :password
-
-    def initialize(email, password)
-      @email = email
-      @password = password
+    def self.load
+      config = YAML.load_file file
+      new(config['mint_email'], config['mint_password'], encrypted: true)
+    rescue => e
+      new('', '').save
     end
+
+    def initialize(email, password, options = {})
+      @email = email
+      @password = options[:encrypted] ? decrypt(password) : password
+    end
+
+    attr_writer :email, :password
 
     def email
       ENV.fetch("MINTY_EMAIL", @email).strip
     end
 
     def password
+      environment_password || @password
+    end
+
+    def environment_password
       ENV.fetch("MINTY_PASSWORD", @password).strip
     end
 
@@ -55,7 +59,7 @@ module Minty
       store = YAML::Store.new self.class.file
       store.transaction {
         store['mint_email'] = email.strip
-        store['mint_password'] = password.strip
+        store['mint_password'] = encrypt(password)
       }
       FileUtils.chmod(0600, self.class.file)
       self
@@ -65,5 +69,24 @@ module Minty
       [email, password].map(&:strip).none?(&:empty?)
     end
 
+    private
+
+    def self.default_key
+      self.file.to_s
+    end
+
+    def cipher(mode, key, data)
+      cipher = OpenSSL::Cipher::Cipher.new('bf-cbc').send(mode)
+      cipher.key = Digest::SHA256.digest(key)
+      cipher.update(data) << cipher.final
+    end
+
+    def encrypt(data, key = self.class.default_key)
+      data.empty? ? '' : cipher(:encrypt, key, data)
+    end
+
+    def decrypt(text, key = self.class.default_key)
+      text.empty? ? '' : cipher(:decrypt, key, text)
+    end
   end
 end

--- a/spec/lib/credentials_spec.rb
+++ b/spec/lib/credentials_spec.rb
@@ -10,7 +10,6 @@ class Minty::Credentials
 end
 
 describe Minty::Credentials do
-
   before do |example|
     Minty::Credentials.reset!
     Minty::Credentials.stub(:filename) { ".fakeminty" }
@@ -20,10 +19,14 @@ describe Minty::Credentials do
     Minty::Credentials.clear!
   end
 
-  it "should be able to clear the credentials" do
+  it "should set @email and @password on initialize" do
     credentials = Minty::Credentials.new('test', 'pass').save
     expect(credentials.email).to eq 'test'
     expect(credentials.password).to eq 'pass'
+  end
+
+  it "should be able to clear the credentials" do
+    credentials = Minty::Credentials.new('test', 'pass').save
     Minty::Credentials.clear!
     credentials = Minty::Credentials.load
     expect(credentials.email).to eq ''
@@ -42,16 +45,14 @@ describe Minty::Credentials do
   end
 
   it "should be able to load credentials" do
-    credentials = Minty::Credentials.new("test", "pass")
-    credentials.save
+    credentials = Minty::Credentials.new("test", "pass").save
     result = Minty::Credentials.load
     expect(result.email).to eq "test"
     expect(result.password).to eq "pass"
   end
 
   it "should be able to update credentials" do
-    credentials = Minty::Credentials.new("test", "pass")
-    credentials.save
+    credentials = Minty::Credentials.new("test", "pass").save
     credentials.email = "test2"
     credentials.save
     result = Minty::Credentials.load
@@ -72,7 +73,7 @@ describe Minty::Credentials do
     ENV["MINTY_PASSWORD"] = 'envpass'
     credentials = Minty::Credentials.load
     credentials.email = "test"
-    credentials.password = "test"
+    credentials.password = "pass"
     credentials.save
     expect(credentials.email).to eq "envtest"
     expect(credentials.password).to eq "envpass"
@@ -91,4 +92,18 @@ describe Minty::Credentials do
     expect(credentials.setup?).to eq true
   end
 
+  it "should encrypt text strings" do
+    password = "pass"
+    credentials = Minty::Credentials.new('test', password)
+    encrypted_password = credentials.send(:encrypt, password)
+    expect(encrypted_password).to_not eq password
+  end
+
+  it "should encrypt and decrypt text strings" do
+    password = "pass"
+    credentials = Minty::Credentials.new('test', password)
+    encrypted_password = credentials.send(:encrypt, password)
+    decrypted_password = credentials.send(:decrypt, encrypted_password)
+    expect(decrypted_password).to eq password
+  end
 end


### PR DESCRIPTION
Chmod 600 the .minty file
The stored file is no longer plaintext, using the file path as the encryption key
Environment variables are still plaintext and take precedence per the test suite
